### PR TITLE
Restore score-test

### DIFF
--- a/scripts/en/phala.sh
+++ b/scripts/en/phala.sh
@@ -216,6 +216,9 @@ case "$1" in
 	uninstall)
 		uninstall
 		;;
+	score-test)
+		score_test $2
+		;;
 	sgx-test)
 		sgx_test
 		;;


### PR DESCRIPTION
Score-test is needed to benchmark cpu and send results to pherry (as required from the chain, to avoid error "poolBenchmarkMissing"