### PR TITLE
Ubuntu 21.10 + Kernel 5.13 Compatability

### DIFF
--- a/scripts/cn/config.sh
+++ b/scripts/cn/config.sh
@@ -68,8 +68,8 @@ function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" 
 
 function config()
 {
-	if version_gt $(uname -r|awk -F "-" '{print $1}') "5.10"; then
-		log_info "----------您的内核版本大于5.10，内核版本过高，请降低内核版本！----------"
+	if version_gt $(uname -r|awk -F "-" '{print $1}') "5.14"; then
+		log_info "----------您的内核版本大于5.13，内核版本过高，请降低内核版本！----------"
 		exit 1
 	fi
 	log_info "----------测试信用等级，正在等待Intel下发IAS远程认证报告！----------"

--- a/scripts/cn/install_phala.sh
+++ b/scripts/cn/install_phala.sh
@@ -188,7 +188,17 @@ elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "20.04" ]; then
 	dcap_driverbin=$(awk -F '/' 'NR==12 {print $NF}' $installdir/.env)
 	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
 	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
+elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "21.04" ]; then
+	dcap_driverurl=$(awk -F '=' 'NR==12 {print $2}' $installdir/.env)
+	dcap_driverbin=$(awk -F '/' 'NR==12 {print $NF}' $installdir/.env)
+	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
+	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
+	elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "21.10" ]; then
+	dcap_driverurl=$(awk -F '=' 'NR==12 {print $2}' $installdir/.env)
+	dcap_driverbin=$(awk -F '/' 'NR==12 {print $NF}' $installdir/.env)
+	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
+	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
 else
-	log_err "----------系统版本不支持，phala目前仅支持Ubuntu 18.04/Ubuntu 20.04----------"
+	log_err "----------系统版本不支持，phala 目前只支持 Ubuntu 18.04/Ubuntu 20.04，对 Ubuntu 21.04/21.10 的支持有限----------"
 	exit 1
 fi

--- a/scripts/cn/phala.sh
+++ b/scripts/cn/phala.sh
@@ -96,8 +96,13 @@ function reportsystemlog()
 		fi
 	done
 
+	if ! type jq curl wget unzip zip docker docker-compose node yq dkms > /dev/null; then install_depenencies;fi
+	if [ ! -L /dev/sgx/enclave ]&&[ ! -L /dev/sgx/provision ]&&[ ! -c /dev/sgx_enclave ]&&[ ! -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then install_driver;fi
+	
+	if [ -c /dev/sgx_vepc ]&&[ -c /dev/sgx ]; then
+		docker run -ti --rm --name phala-sgx_detect --device /dev/sgx --device /dev/sgx_provision --device /dev/sgx_enclave --device /dev/sgx_vepc phalanetwork/phala-sgx_detect
 	if [ -L /dev/sgx/enclave ]&&[ -L /dev/sgx/provision ]&&[ -c /dev/sgx_enclave ]&&[ -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then
-		docker run -dti --rm --name phala-sgx_detect --device /dev/sgx/enclave --device /dev/sgx/provision --device /dev/sgx_enclave --device /dev/sgx_provision swr.cn-east-3.myhuaweicloud.com/phala/phala-sgx_detect > /tmp/systemlog/testdocker-dcap.inf
+		docker run -ti --rm --name phala-sgx_detect --device /dev/sgx/enclave --device /dev/sgx/provision --device /dev/sgx_enclave --device /dev/sgx_provision phalanetwork/phala-sgx_detect:latest
 	elif [ ! -L /dev/sgx/enclave ]&&[ -L /dev/sgx/provision ]&&[ -c /dev/sgx_enclave ]&&[ -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then
 		docker run -dti --rm --name phala-sgx_detect --device /dev/sgx/provision --device /dev/sgx_enclave --device /dev/sgx_provision swr.cn-east-3.myhuaweicloud.com/phala/phala-sgx_detect > /tmp/systemlog/testdocker-dcap.inf
 	elif [ ! -L /dev/sgx/enclave ]&&[ ! -L /dev/sgx/provision ]&&[ -c /dev/sgx_enclave ]&&[ -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then

--- a/scripts/en/config.sh
+++ b/scripts/en/config.sh
@@ -68,8 +68,8 @@ function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" 
 
 function config()
 {
-	if version_gt $(uname -r|awk -F "-" '{print $1}') "5.10"; then
-		log_info "----------Your kernel version is greater than 5.10, the kernel version is too high.Please lower the kernel version!----------"
+	if version_gt $(uname -r|awk -F "-" '{print $1}') "5.14"; then
+		log_info "----------Your kernel version is greater than 5.13, the kernel version is too high. Please lower the kernel version!----------"
 		exit 1
 	fi
 	log_info "----------Test confidenceLevel, waiting for Intel to issue IAS remote certification report!----------"

--- a/scripts/en/install_phala.sh
+++ b/scripts/en/install_phala.sh
@@ -193,6 +193,11 @@ elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "21.04" ]; then
 	dcap_driverbin=$(awk -F '/' 'NR==12 {print $NF}' $installdir/.env)
 	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
 	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
+	elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "21.10" ]; then
+	dcap_driverurl=$(awk -F '=' 'NR==12 {print $2}' $installdir/.env)
+	dcap_driverbin=$(awk -F '/' 'NR==12 {print $NF}' $installdir/.env)
+	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
+	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
 else
 	log_err "----------Your system is not supported. Phala currently only supports Ubuntu 18.04/Ubuntu 20.04----------"
 	exit 1

--- a/scripts/en/install_phala.sh
+++ b/scripts/en/install_phala.sh
@@ -199,6 +199,6 @@ elif [ $(lsb_release -r | grep -o "[0-9]*\.[0-9]*") = "21.04" ]; then
 	isgx_driverurl=$(awk -F '=' 'NR==14 {print $2}' $installdir/.env)
 	isgx_driverbin=$(awk -F '/' 'NR==14 {print $NF}' $installdir/.env)
 else
-	log_err "----------Your system is not supported. Phala currently only supports Ubuntu 18.04/Ubuntu 20.04----------"
+	log_err "----------Your system is not supported. Phala currently supports Ubuntu 18.04/Ubuntu 20.04 & limited support for Ubuntu 21.04/21.10 ----------"
 	exit 1
 fi

--- a/scripts/en/phala.sh
+++ b/scripts/en/phala.sh
@@ -55,7 +55,9 @@ function sgx_test()
 {
 	if ! type jq curl wget unzip zip docker docker-compose node yq dkms > /dev/null; then install_depenencies;fi
 	if [ ! -L /dev/sgx/enclave ]&&[ ! -L /dev/sgx/provision ]&&[ ! -c /dev/sgx_enclave ]&&[ ! -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then install_driver;fi
-
+	
+	if [ -c /dev/sgx_vepc ]&&[ -c /dev/sgx ]; then
+		docker run -ti --rm --name phala-sgx_detect --device /dev/sgx --device /dev/sgx_provision --device /dev/sgx_enclave --device /dev/sgx_vepc phalanetwork/phala-sgx_detect
 	if [ -L /dev/sgx/enclave ]&&[ -L /dev/sgx/provision ]&&[ -c /dev/sgx_enclave ]&&[ -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then
 		docker run -ti --rm --name phala-sgx_detect --device /dev/sgx/enclave --device /dev/sgx/provision --device /dev/sgx_enclave --device /dev/sgx_provision phalanetwork/phala-sgx_detect:latest
 	elif [ ! -L /dev/sgx/enclave ]&&[ -L /dev/sgx/provision ]&&[ -c /dev/sgx_enclave ]&&[ -c /dev/sgx_provision ]&&[ ! -c /dev/isgx ]; then


### PR DESCRIPTION
Less DCAP driver issues with kernel 5.13 as it seems to be natively supported and setup were faster with Ubuntu 21.10 as well. 
@skysummerice please check in `phala.sh` under the `sgx_test` function that your addition is correct syntax-wise. 