### PR TITLE
Remove no longer needed extra args for khala-node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
    environment:
     - NODE_NAME=${NODE_NAME}
     - NODE_ROLE=MINER
-    - "PARACHAIN_EXTRA_ARGS=--state-cache-size 671088640 --db-cache 2048 --max-runtime-instances 16"
-    - "RELAYCHAIN_EXTRA_ARGS=--state-cache-size 671088640 --db-cache 2048 --max-runtime-instances 16"
    volumes:
     - ${NODE_VOLUMES}
 


### PR DESCRIPTION
latest khala-node docker image bundled `--db-cache 2048` which is the key argument for performance in our research, `--state-cache-size 671088640 --max-runtime-instances 16` is harm for performance actually so we shouldn't use them